### PR TITLE
fix: IndexedDB 캐시 TTL/LRU/용량 제한 추가 (#6)

### DIFF
--- a/frontend/src/hooks/useTTSSoundEngine.ts
+++ b/frontend/src/hooks/useTTSSoundEngine.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSoundEngine } from './useSoundEngine';
+import { TTSAudioCache } from '../services/ttsAudioCache';
+import { checkTTSServerHealth } from '../services/ttsApiClient';
+import { evictStaleCache } from '../services/ttsIndexedDB';
+import type { ToneName } from '../utils/toneMapping';
+
+export interface PreloadProgress {
+  loaded: number;
+  total: number;
+}
+
+export function useTTSSoundEngine() {
+  const sound = useSoundEngine();
+  const { isSoundEnabled, getCtx, toggleSound } = sound;
+  const [ttsServerConnected, setTTSServerConnected] = useState<boolean | null>(
+    null
+  );
+  const [isPreloading, setIsPreloading] = useState(false);
+  const [preloadProgress, setPreloadProgress] = useState<PreloadProgress>({
+    loaded: 0,
+    total: 0,
+  });
+
+  useEffect(() => {
+    checkTTSServerHealth().then(setTTSServerConnected);
+    evictStaleCache().catch(() => {});
+  }, []);
+
+  const cacheRef = useRef<TTSAudioCache | null>(null);
+
+  const getCache = useCallback(() => {
+    if (!cacheRef.current) {
+      const ctx = getCtx();
+      cacheRef.current = new TTSAudioCache(ctx);
+    }
+    return cacheRef.current;
+  }, [getCtx]);
+
+  const playWord = useCallback(
+    async (word: string, tone?: ToneName) => {
+      if (!isSoundEnabled || !word) return;
+
+      const cache = getCache();
+      const buffer =
+        cache.get(word, tone) ?? (await cache.getOrFetch(word, tone));
+      if (!buffer) return;
+
+      try {
+        const ctx = getCtx();
+        if (ctx.state === 'suspended') await ctx.resume();
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        const gain = ctx.createGain();
+        gain.gain.value = 0.8;
+        source.connect(gain).connect(ctx.destination);
+        source.start();
+      } catch (err) {
+        console.warn('[TTS] 오디오 재생 실패:', err);
+      }
+    },
+    [isSoundEnabled, getCtx, getCache]
+  );
+
+  const preloadText = useCallback(
+    async (text: string): Promise<void> => {
+      const words = text
+        .split(/\s+/)
+        .map(w => w.replace(/[^가-힣]/g, ''))
+        .filter(Boolean);
+      if (words.length === 0) return;
+      const uniqueWords = [...new Set(words)];
+      const cache = getCache();
+
+      setIsPreloading(true);
+      setPreloadProgress({ loaded: 0, total: uniqueWords.length });
+
+      const POLL_INTERVAL = 100;
+      const pollId = setInterval(() => {
+        const progress = cache.getPreloadProgress();
+        setPreloadProgress(() => {
+          // total은 uncached 기준이므로, loaded가 진행되면 전체 대비 환산
+          const idbLoaded = uniqueWords.length - progress.total;
+          return {
+            loaded: idbLoaded + progress.loaded,
+            total: uniqueWords.length,
+          };
+        });
+      }, POLL_INTERVAL);
+
+      const DEFAULT_TONE: ToneName = 'excited';
+      const wordsWithTone = uniqueWords.map(w => ({
+        word: w,
+        tone: DEFAULT_TONE,
+      }));
+
+      try {
+        await cache.preloadChars(wordsWithTone);
+      } finally {
+        clearInterval(pollId);
+        setPreloadProgress({
+          loaded: uniqueWords.length,
+          total: uniqueWords.length,
+        });
+        setIsPreloading(false);
+      }
+    },
+    [getCache]
+  );
+
+  return {
+    isSoundEnabled,
+    toggleSound,
+    playWord,
+    preloadText,
+    ttsServerConnected,
+    isPreloading,
+    preloadProgress,
+  };
+}

--- a/frontend/src/services/ttsIndexedDB.ts
+++ b/frontend/src/services/ttsIndexedDB.ts
@@ -1,6 +1,25 @@
 const DB_NAME = 'tts-audio-cache';
 const STORE_NAME = 'syllables';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
+
+const MAX_CACHE_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7일
+const MAX_CACHE_BYTES = 50 * 1024 * 1024; // 50MB
+
+interface CacheEntry {
+  data: ArrayBuffer;
+  timestamp: number;
+  size: number;
+}
+
+function isCacheEntry(value: unknown): value is CacheEntry {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'data' in value &&
+    'timestamp' in value &&
+    'size' in value
+  );
+}
 
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -8,7 +27,16 @@ function openDB(): Promise<IDBDatabase> {
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME);
+        const store = db.createObjectStore(STORE_NAME);
+        store.createIndex('timestamp', 'timestamp', { unique: false });
+      } else {
+        const tx = req.transaction;
+        if (tx) {
+          const store = tx.objectStore(STORE_NAME);
+          if (!store.indexNames.contains('timestamp')) {
+            store.createIndex('timestamp', 'timestamp', { unique: false });
+          }
+        }
       }
     };
     req.onsuccess = () => resolve(req.result);
@@ -28,6 +56,13 @@ function getDB(): Promise<IDBDatabase> {
   return dbPromise;
 }
 
+/** v1 raw ArrayBuffer → v2 CacheEntry 변환 */
+function resolveEntry(raw: unknown): ArrayBuffer | null {
+  if (isCacheEntry(raw)) return raw.data;
+  if (raw instanceof ArrayBuffer) return raw;
+  return null;
+}
+
 export async function getCachedAudio(
   char: string
 ): Promise<ArrayBuffer | null> {
@@ -37,7 +72,14 @@ export async function getCachedAudio(
       const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
       const req = store.get(char);
-      req.onsuccess = () => resolve(req.result ?? null);
+      req.onsuccess = () => {
+        const data = resolveEntry(req.result);
+        if (data) {
+          // LRU touch: 타임스탬프 갱신 (fire-and-forget)
+          touchEntry(char, data).catch(() => {});
+        }
+        resolve(data);
+      };
       req.onerror = () => reject(req.error);
     });
   } catch (err) {
@@ -46,16 +88,33 @@ export async function getCachedAudio(
   }
 }
 
+async function touchEntry(char: string, data: ArrayBuffer): Promise<void> {
+  const db = await getDB();
+  const entry: CacheEntry = {
+    data,
+    timestamp: Date.now(),
+    size: data.byteLength,
+  };
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  store.put(entry, char);
+}
+
 export async function setCachedAudio(
   char: string,
   data: ArrayBuffer
 ): Promise<void> {
   try {
     const db = await getDB();
+    const entry: CacheEntry = {
+      data,
+      timestamp: Date.now(),
+      size: data.byteLength,
+    };
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       const store = tx.objectStore(STORE_NAME);
-      const req = store.put(data, char);
+      const req = store.put(entry, char);
       req.onsuccess = () => resolve();
       req.onerror = () => reject(req.error);
     });
@@ -81,7 +140,8 @@ export async function getCachedAudioBatch(
       for (const char of chars) {
         const req = store.get(char);
         req.onsuccess = () => {
-          if (req.result) result.set(char, req.result);
+          const data = resolveEntry(req.result);
+          if (data) result.set(char, data);
           if (++completed === chars.length) resolve(result);
         };
         req.onerror = () => {
@@ -94,4 +154,103 @@ export async function getCachedAudioBatch(
     console.warn('[TTS] IndexedDB 배치 조회 실패:', err);
     return result;
   }
+}
+
+export async function evictStaleCache(): Promise<void> {
+  try {
+    const db = await getDB();
+    const cutoff = Date.now() - MAX_CACHE_AGE_MS;
+
+    // 1단계: 7일 초과 항목 삭제
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const index = store.index('timestamp');
+      const range = IDBKeyRange.upperBound(cutoff);
+      const cursorReq = index.openCursor(range);
+      cursorReq.onsuccess = () => {
+        const cursor = cursorReq.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+        }
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+
+    // v1 마이그레이션: timestamp 없는 레거시 항목도 정리
+    await evictLegacyEntries(db);
+
+    // 2단계: 용량 제한 — 50MB 초과 시 오래된 순 삭제
+    await evictBySize(db);
+  } catch (err) {
+    console.warn('[TTS] IndexedDB 캐시 정리 실패:', err);
+  }
+}
+
+async function evictLegacyEntries(db: IDBDatabase): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const cursorReq = store.openCursor();
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (cursor) {
+        if (!isCacheEntry(cursor.value)) {
+          cursor.delete();
+        }
+        cursor.continue();
+      }
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function evictBySize(db: IDBDatabase): Promise<void> {
+  // 타임스탬프 오름차순으로 모든 엔트리의 키와 사이즈 수집
+  const entries: Array<{ key: IDBValidKey; size: number }> = [];
+  let totalSize = 0;
+
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const index = store.index('timestamp');
+    const cursorReq = index.openCursor();
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (cursor) {
+        const entry = cursor.value as CacheEntry;
+        const size = entry.size ?? 0;
+        entries.push({ key: cursor.primaryKey, size });
+        totalSize += size;
+        cursor.continue();
+      }
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+
+  if (totalSize <= MAX_CACHE_BYTES) return;
+
+  // 오래된 순(배열 앞쪽)부터 삭제
+  const keysToDelete: IDBValidKey[] = [];
+  for (const entry of entries) {
+    if (totalSize <= MAX_CACHE_BYTES) break;
+    keysToDelete.push(entry.key);
+    totalSize -= entry.size;
+  }
+
+  if (keysToDelete.length === 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    for (const key of keysToDelete) {
+      store.delete(key);
+    }
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
 }


### PR DESCRIPTION
## Summary
- **Issue**: IndexedDB에 만료 정책 없이 무한 축적 → 모바일 스토리지 경고, 구버전 음성 잔존
- **Fix**: CacheEntry 구조체 + 7일 TTL + 50MB 용량 제한 + v1 마이그레이션
- **Result**: 캐시 자동 관리, 스토리지 압력 해소, 음성 모델 업데이트 반영

## Changes
- `ttsIndexedDB.ts`: DB_VERSION 2, CacheEntry 인터페이스, evictStaleCache(), evictBySize(), evictLegacyEntries()
- `useTTSSoundEngine.ts`: 앱 시작 시 evictStaleCache() 호출

## Architecture
```
앱 시작 → evictStaleCache()
  ├─ 1단계: timestamp < (now - 7일) 항목 삭제 (인덱스 활용)
  ├─ 2단계: v1 레거시 항목 (raw ArrayBuffer) 삭제
  └─ 3단계: 총 용량 > 50MB이면 오래된 순 삭제
```

## Test plan
- [x] ESLint 통과
- [x] TypeScript 타입 체크 통과
- [ ] DB v1 → v2 마이그레이션 정상 동작 확인
- [ ] 7일 초과 항목 자동 삭제 확인
- [ ] 50MB 초과 시 오래된 항목 삭제 확인

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)